### PR TITLE
Add Docker environment for Project AirSim client

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.swp
+*.swo
+*.log
+build/
+dist/
+*.egg-info/
+docs/_build/
+node_modules/
+.pytest_cache/
+.mypy_cache/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.10-slim
+
+# Prevent Python from writing .pyc files and enable unbuffered output
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# Install build prerequisites and runtime libraries required by the
+# Project AirSim Python client dependencies.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the client sources into the image so we can install the package and
+# provide an immutable fallback even when the repository is mounted as a
+# volume at runtime.
+COPY projectairsim /opt/projectairsim
+COPY docker/entrypoint.sh /opt/entrypoint.sh
+
+WORKDIR /opt/projectairsim
+
+# Install the Project AirSim package and its Python dependencies.
+RUN pip install --upgrade pip \
+    && pip install -r requirements.txt \
+    && chmod +x /opt/entrypoint.sh
+
+# Working directory used when the container starts. When docker compose is
+# used, the repository is mounted at /workspace so that local changes are
+# visible inside the container.
+RUN mkdir -p /workspace
+
+WORKDIR /workspace
+
+ENTRYPOINT ["/opt/entrypoint.sh"]
+CMD ["bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,74 @@
+# Project AirSim Docker Client
+
+This directory contains a Docker based workflow for running the Project AirSim
+Python client inside WSL2 while the AirSim simulation continues to run on the
+Windows host. The container talks to the host through TCP which allows the
+client to publish and subscribe to the AirSim simulation topics.
+
+## Prerequisites
+
+* Windows 11 with WSL2 and Docker Desktop installed.
+* The AirSim fork [`iamaisim/ProjectAirSim`](https://github.com/iamaisim/ProjectAirSim)
+  running on the Windows host.
+* This repository checked out inside WSL2 (for example at
+  `/home/<user>/projects/airsim_docker_client`).
+
+## Build the client image
+
+```bash
+cd docker
+docker compose build
+```
+
+The build installs all Python dependencies declared by the `projectairsim`
+package, including `pynng`, `opencv-python`, and other scientific libraries.
+
+## Start an interactive client shell
+
+```bash
+docker compose run --rm projectairsim-client
+```
+
+The service mounts the repository into `/workspace` and drops you into an
+interactive Bash shell where you can execute any of the example scripts, e.g.
+
+```bash
+python example_user_scripts/hello_drone.py
+```
+
+### Host connectivity
+
+The `entrypoint.sh` script resolves the Windows host IP automatically using the
+gateway defined in `/etc/resolv.conf`. When necessary you can override the host
+IP and ports in the shell before launching the container:
+
+```bash
+export PROJECTAIRSIM_HOST=192.168.0.10
+export PROJECTAIRSIM_PORT_TOPICS=8989
+export PROJECTAIRSIM_PORT_SERVICES=8990
+docker compose run --rm projectairsim-client
+```
+
+Inside the container these values are exposed to the Python client through
+environment variables, enabling TCP communication with the AirSim instance
+running on Windows.
+
+### Disable the editable install
+
+By default the container runs `pip install --editable /workspace/projectairsim`
+on startup so that code changes made on the host are reflected immediately.
+When you prefer using the immutable package baked into the image, disable the
+step via:
+
+```bash
+PROJECTAIRSIM_EDITABLE_INSTALL=0 docker compose run --rm projectairsim-client
+```
+
+## Stop and clean up
+
+```bash
+docker compose down --rmi local --volumes --remove-orphans
+```
+
+This removes containers created for the client, any anonymous volumes, and the
+locally built image.

--- a/docker/client.env
+++ b/docker/client.env
@@ -1,0 +1,6 @@
+# Default environment variables consumed by docker compose. Values can be
+# overridden via the shell environment when running `docker compose`.
+PROJECTAIRSIM_HOST=auto
+PROJECTAIRSIM_PORT_TOPICS=8989
+PROJECTAIRSIM_PORT_SERVICES=8990
+PROJECTAIRSIM_EDITABLE_INSTALL=1

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,20 @@
+version: "3.9"
+
+services:
+  projectairsim-client:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: projectairsim/client:latest
+    env_file:
+      - client.env
+    environment:
+      # Allow overriding via "docker compose run" while defaulting to the
+      # gateway IP detected by entrypoint.sh.
+      PROJECTAIRSIM_HOST: ${PROJECTAIRSIM_HOST:-auto}
+      PROJECTAIRSIM_PORT_TOPICS: ${PROJECTAIRSIM_PORT_TOPICS:-8989}
+      PROJECTAIRSIM_PORT_SERVICES: ${PROJECTAIRSIM_PORT_SERVICES:-8990}
+    volumes:
+      - ..:/workspace:delegated
+    working_dir: /workspace
+    command: ["bash"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Optionally re-install the project in editable mode so that local changes
+# mounted into the container are picked up immediately.
+if [[ "${PROJECTAIRSIM_EDITABLE_INSTALL:-1}" != "0" && -d /workspace/projectairsim ]]; then
+    pip install --editable /workspace/projectairsim >/tmp/pip-projectairsim.log 2>&1 || {
+        cat /tmp/pip-projectairsim.log >&2
+        echo "Failed to install Project AirSim in editable mode" >&2
+        exit 1
+    }
+fi
+
+# Resolve the IP address of the Windows host when PROJECTAIRSIM_HOST is set
+# to "auto" (the default). In WSL2 the Windows host is reachable through the
+# first DNS entry listed in /etc/resolv.conf. Fallback to host.docker.internal
+# when the lookup fails so the user can still override it manually.
+if [[ "${PROJECTAIRSIM_HOST:-auto}" == "auto" ]]; then
+    gateway_ip=$(awk '/nameserver/ {print $2; exit}' /etc/resolv.conf || true)
+    if [[ -n "${gateway_ip}" ]]; then
+        export PROJECTAIRSIM_HOST="${gateway_ip}"
+    else
+        export PROJECTAIRSIM_HOST="host.docker.internal"
+    fi
+fi
+
+exec "$@"

--- a/projectairsim/src/projectairsim/client.py
+++ b/projectairsim/src/projectairsim/client.py
@@ -13,6 +13,7 @@ import cryptography.hazmat.primitives.asymmetric.padding
 import cryptography.hazmat.primitives.hashes
 import inspect
 import json
+import os
 import random
 import threading
 import time
@@ -30,6 +31,31 @@ from projectairsim.utils import projectairsim_log
 
 class ProjectAirSimClient:
     def __init__(self, address="127.0.0.1", port_topics=8989, port_services=8990):
+        env_address = os.environ.get("PROJECTAIRSIM_HOST")
+        env_port_topics = os.environ.get("PROJECTAIRSIM_PORT_TOPICS")
+        env_port_services = os.environ.get("PROJECTAIRSIM_PORT_SERVICES")
+
+        if env_address:
+            address = env_address
+        if env_port_topics:
+            try:
+                port_topics = int(env_port_topics)
+            except ValueError:
+                utils.projectairsim_log().warning(
+                    "Invalid PROJECTAIRSIM_PORT_TOPICS value '%s', using default %s",
+                    env_port_topics,
+                    port_topics,
+                )
+        if env_port_services:
+            try:
+                port_services = int(env_port_services)
+            except ValueError:
+                utils.projectairsim_log().warning(
+                    "Invalid PROJECTAIRSIM_PORT_SERVICES value '%s', using default %s",
+                    env_port_services,
+                    port_services,
+                )
+
         self.topics = {}
         self.subs = {}
         self.recv_topic_thread = None


### PR DESCRIPTION
## Summary
- add a Docker image, compose file, and helper scripts to run the Project AirSim Python client inside WSL2
- document the workflow and default environment variables for connecting the containerized client to the Windows host
- allow ProjectAirSimClient to read host and port overrides from environment variables for TCP connectivity

## Testing
- python -m compileall src/projectairsim/client.py

------
https://chatgpt.com/codex/tasks/task_e_68e3f70700ec832d86c9626659e0fdad