### PR TITLE
Install client without virtualenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.8-slim
+
+# Install system dependencies required for building Python packages.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        git \
+        iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory for Project AirSim assets.
+WORKDIR /opt/projectairsim
+
+ENV PYTHONUNBUFFERED=1
+
+# Upgrade packaging tools and install build prerequisites using the system interpreter.
+RUN pip install --upgrade pip \
+    && pip install setuptools wheel cmake
+
+# Copy the Project AirSim Python client and supporting scripts.
+COPY projectairsim ./projectairsim
+COPY example_user_scripts ./example_user_scripts
+COPY docker_entrypoint.sh ./entrypoint.sh
+
+# Install the Project AirSim Python client in editable mode.
+RUN pip install -e ./projectairsim
+
+# Ensure the entrypoint script is executable.
+RUN chmod +x /opt/projectairsim/entrypoint.sh
+
+ENTRYPOINT ["/opt/projectairsim/entrypoint.sh"]

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Derive the Windows host IP accessible from WSL2.
+WSL_GATEWAY="$(ip route show | awk '/^default/ {print $3; exit}')"
+WSL_HOST_IP=${WSL_HOST_IP:-$WSL_GATEWAY}
+
+PORT_TOPICS=${PORT_TOPICS:-8989}
+PORT_SERVICES=${PORT_SERVICES:-8990}
+
+if [[ -n "${1-}" ]]; then
+  echo "Overriding connection parameters with user-provided arguments: $*"
+  exec python /opt/projectairsim/example_user_scripts/hello_drone.py "$@"
+fi
+
+echo "Connecting to Project AirSim services via ${WSL_HOST_IP}:${PORT_TOPICS}/${PORT_SERVICES}"
+
+exec python /opt/projectairsim/example_user_scripts/hello_drone.py \
+  --address "${WSL_HOST_IP}" \
+  --port-topics "${PORT_TOPICS}" \
+  --port-services "${PORT_SERVICES}"

--- a/example_user_scripts/qgc_connector.py
+++ b/example_user_scripts/qgc_connector.py
@@ -1,0 +1,41 @@
+"""
+Simple connector script to establish Project AirSim <-> PX4 connection for QGroundControl use.
+Keep this running while using QGC.
+"""
+
+import asyncio
+from projectairsim import ProjectAirSimClient, Drone, World
+from projectairsim.utils import projectairsim_log
+
+
+async def maintain_connection():
+    client = ProjectAirSimClient()
+    
+    try:
+        # Connect to simulation environment
+        client.connect()
+        
+        # Create a World object and load the scene
+        world = World(client, "scene_px4_sitl.jsonc", delay_after_load_sec=2)
+        
+        # Create a Drone object to establish the connection
+        drone = Drone(client, world, "Drone1")
+        
+        projectairsim_log().info("Connection established. QGroundControl can now connect to localhost:14550")
+        projectairsim_log().info("Keep this script running while using QGC. Press Ctrl+C to stop.")
+        
+        # Keep the connection alive
+        while True:
+            await asyncio.sleep(10)
+            projectairsim_log().info("Connection maintained...")
+            
+    except KeyboardInterrupt:
+        projectairsim_log().info("Connection script stopped by user")
+    except Exception as e:
+        projectairsim_log().error(f"Error: {e}")
+    finally:
+        client.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(maintain_connection())

--- a/example_user_scripts/qgc_connector_with_wind.py
+++ b/example_user_scripts/qgc_connector_with_wind.py
@@ -1,0 +1,122 @@
+"""
+QGC Connector with Altitude-Based Wind Application
+
+Establishes Project AirSim <-> PX4 connection for QGroundControl use.
+Automatically applies wind when drone is above 10m altitude above ground.
+Keep this running while using QGC.
+"""
+
+import asyncio
+from projectairsim import ProjectAirSimClient, Drone, World
+from projectairsim.utils import projectairsim_log
+
+
+# Wind parameters to apply when above threshold
+WIND_VEL_X = 0.0  # m/s in North direction
+WIND_VEL_Y = 20  # m/s in East direction
+WIND_VEL_Z = 0.0  # m/s in Down direction
+ALTITUDE_THRESHOLD = 10 # meters above ground
+CHECK_INTERVAL = 0.5  # seconds between altitude checks
+
+
+async def monitor_altitude_and_apply_wind(drone, world):
+    """
+    Monitors drone altitude and applies wind when above threshold.
+    
+    Args:
+        drone: Drone object
+        world: World object
+    """
+    wind_active = False
+    ground_altitude = None
+    
+    while True:
+        try:
+            # Get current geo location (includes altitude above sea level)
+            geo_location = drone.get_ground_truth_geo_location()
+            current_altitude = geo_location["altitude"]
+            
+            # Initialize ground altitude on first reading
+            if ground_altitude is None:
+                ground_altitude = current_altitude
+                projectairsim_log().info(f"Ground altitude initialized: {ground_altitude:.2f}m")
+            
+            # Calculate altitude above ground
+            altitude_agl = current_altitude - ground_altitude
+            
+            # Check if we need to apply or remove wind
+            if altitude_agl > ALTITUDE_THRESHOLD and not wind_active:
+                projectairsim_log().info(
+                    f"Altitude {altitude_agl:.2f}m > {ALTITUDE_THRESHOLD}m - Applying wind "
+                    f"(x={WIND_VEL_X}, y={WIND_VEL_Y}, z={WIND_VEL_Z})"
+                )
+                world.set_wind_velocity(WIND_VEL_X, WIND_VEL_Y, WIND_VEL_Z)
+                wind_active = True
+                
+            elif altitude_agl <= ALTITUDE_THRESHOLD and wind_active:
+                projectairsim_log().info(
+                    f"Altitude {altitude_agl:.2f}m <= {ALTITUDE_THRESHOLD}m - Removing wind"
+                )
+                world.set_wind_velocity(0.0, 0.0, 0.0)
+                wind_active = False
+            
+            # Periodically log altitude (every 2 seconds)
+            if int(asyncio.get_event_loop().time()) % 2 == 0:
+                projectairsim_log().debug(
+                    f"Altitude AGL: {altitude_agl:.2f}m | Wind: {'ON' if wind_active else 'OFF'}"
+                )
+            
+        except Exception as e:
+            projectairsim_log().error(f"Error monitoring altitude: {e}")
+        
+        await asyncio.sleep(CHECK_INTERVAL)
+
+
+async def maintain_connection():
+    client = ProjectAirSimClient()
+    
+    try:
+        # Connect to simulation environment
+        client.connect()
+        projectairsim_log().info("Connected to Project AirSim")
+        
+        # Create a World object and load the scene
+        world = World(client, "scene_px4_sitl.jsonc", delay_after_load_sec=2)
+        projectairsim_log().info("Scene loaded")
+        
+        # Create a Drone object to establish the connection
+        drone = Drone(client, world, "Drone1")
+        
+        projectairsim_log().info("=" * 60)
+        projectairsim_log().info("Connection established!")
+        projectairsim_log().info("QGroundControl can now connect to localhost:14550")
+        projectairsim_log().info(f"Wind will be applied when altitude > {ALTITUDE_THRESHOLD}m AGL")
+        projectairsim_log().info("Keep this script running while using QGC.")
+        projectairsim_log().info("Press Ctrl+C to stop.")
+        projectairsim_log().info("=" * 60)
+        
+        # Start altitude monitoring task
+        monitor_task = asyncio.create_task(monitor_altitude_and_apply_wind(drone, world))
+        
+        # Keep the connection alive
+        while True:
+            await asyncio.sleep(10)
+            projectairsim_log().info("Connection maintained...")
+            
+    except KeyboardInterrupt:
+        projectairsim_log().info("Connection script stopped by user")
+    except Exception as e:
+        projectairsim_log().error(f"Error: {e}", exc_info=True)
+    finally:
+        # Ensure wind is disabled before disconnecting
+        try:
+            world.set_wind_velocity(0.0, 0.0, 0.0)
+            projectairsim_log().info("Wind disabled")
+        except:
+            pass
+        client.disconnect()
+        projectairsim_log().info("Disconnected from simulation")
+
+
+if __name__ == "__main__":
+    asyncio.run(maintain_connection())


### PR DESCRIPTION
## Summary
- update the Python 3.8-based Dockerfile to install the Project AirSim client directly without creating a virtual environment
- keep the entrypoint script that discovers the WSL host IP and starts the hello_drone demo with the required ports

## Testing
- Not Run (docker CLI unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ea5839fee0832d84d36513e2da4f51